### PR TITLE
Prepare CI

### DIFF
--- a/.github/actions.yml
+++ b/.github/actions.yml
@@ -1,0 +1,2 @@
+pre:
+  docs: 'gem install jekyll -v 4'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,11 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/47degrees/.github
+# If you want to suggest a change, please open a PR or issue in that repository
+
+enhancement: ['enhancement/*', 'feature/*']
+documentation: ['docs/*', 'doc/*']
+breaking-change: ['breaking/*', 'break/*']
+bug: ['bug/*', 'fix/*']
+tests: ['test/*', 'tests/*']
+dependency-update: ['dep/*', 'dependency/*', 'dependency-update/*']
+scala-steward: ['update/*']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,63 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/47degrees/.github
+# If you want to suggest a change, please open a PR or issue in that repository
+
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-labels:
+  - 'auto-update'
+  - 'auto-documentation'
+  - 'auto-changelog'
+categories:
+  - title: '⚠️ Breaking changes'
+    label: 'breaking-change'
+  - title: '🚀 Features'
+    label: 'enhancement'
+  - title: '📘 Documentation'
+    label: 'documentation'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '📈 Dependency updates'
+    labels:
+      - 'dependency-update'
+      - 'scala-steward'
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  ## Contributors to this release
+
+  $CONTRIBUTORS
+
+autolabeler:
+  - label: "enhancement"
+    branch:
+      - '/enhancement\/.+/'
+      - '/feature\/.+/'
+  - label: "documentation"
+    files:
+      - "*.md"
+    branch:
+      - '/docs\/.+/'
+      - '/doc\/.+/'
+  - label: "breaking-change"
+    branch:
+      - '/breaking\/.+/'
+      - '/break\/.+/'
+  - label: "bug"
+    branch:
+      - '/bug\/.+/'
+      - '/fix\/.+/'
+  - label: "tests"
+    branch:
+      - '/test\/.+/'
+      - '/tests\/.+/'
+  - label: "dependency-update"
+    branch:
+      - '/dep\/.+/'
+      - '/dependency\/.+/'
+      - '/dependency-update\/.+/'
+  - label: "scala-steward"
+    branch:
+      - '/update\/.+/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/47degrees/.github
+# If you want to suggest a change, please open a PR or issue in that repository
+
+name: Formatters & Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project (pull-request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v2.3.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Checkout project (main)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+      - name: Setup yq
+        run: sudo snap install yq
+      - name: Run pre-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.pre.ci // "true"' .github/actions.yml)" || true
+      - name: Run scalafmt on Scala Steward PRs
+        if: github.event.pull_request.user.login == '47erbot' && contains(github.event.pull_request.body, 'Scala Steward')
+        run: sbt "scalafixEnable; fix" || sbt "scalafmtAll; scalafmtSbt" || true
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v4.5.1
+        with:
+          commit_message: Run formatter/linter
+      - name: Run checks
+        run: sbt ci-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+      - name: Run post-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.post.ci // "true"' .github/actions.yml)" || true
+      - name: Automerge Scala Steward PRs
+        if: success() && github.event_name == 'pull_request' && contains(github.event.pull_request.body, 'Scala Steward')
+        uses: ridedott/merge-me-action@v1.1.36
+        with:
+          GITHUB_LOGIN: 47erbot
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/47degrees/.github
+# If you want to suggest a change, please open a PR or issue in that repository
+
+name: Update documentation
+
+on:
+  release:
+    types: [published]
+  repository_dispatch:
+    types: [docs]
+
+jobs:
+  documentation:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          ref: main
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+      - name: Setup github-changelog-generator
+        run: gem install github_changelog_generator -v 1.15.0
+      - name: Setup yq
+        run: sudo snap install yq
+      - name: Run pre-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.pre.docs // "true"' .github/actions.yml)" || true
+      - name: Generate documentation
+        run: sbt ci-docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOWNLOAD_INFO_FROM_GITHUB: true
+      - name: Run post-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.post.docs // "true"' .github/actions.yml)" || true
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.3
+        with:
+          commit_message: 'Update documentation, and other files [skip ci]'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Drafts/updates the next repository release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# Don't edit this file!
+# It is automatically updated after every release of https://github.com/47degrees/.github
+# If you want to suggest a change, please open a PR or issue in that repository
+
+name: Release
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: main
+
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+      - name: Setup GPG
+        uses: olafurpg/setup-gpg@v3
+      - name: Setup yq
+        run: sudo snap install yq
+      - name: Run pre-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.pre.release // "true"' .github/actions.yml)" || true
+      - name: Release new version
+        run: sbt ci-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      - name: Run post-conditions
+        run: test -f .github/actions.yml && eval "$(yq e '.post.release // "true"' .github/actions.yml)" || true

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,7 @@
+-J-Xmx5g
+-J-XX:+CMSClassUnloadingEnabled
+-J-XX:MaxMetaspaceSize=1g
+-J-XX:+HeapDumpOnOutOfMemoryError
+-Djava.awt.headless=true
+-Dfile.encoding=utf8
+-Duser.timezone=UTC

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,9 +8,10 @@
 
 The maintainers of the project are:
 
-
+- [![sloshy](https://avatars.githubusercontent.com/u/427237?v=4&s=20) **Ryan Peters (sloshy)**](https://github.com/sloshy)
 
 ## Contributors
 
 These are the people that have contributed to the _fetchless_ project:
 
+- [![sloshy](https://avatars.githubusercontent.com/u/427237?v=4&s=20) **sloshy**](https://github.com/sloshy)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,8 +2,15 @@
 [comment]: <> (It is automatically updated after every release of https://github.com/47degrees/.github)
 [comment]: <> (If you want to suggest a change, please open a PR or issue in that repository)
 
-fetchless
+# Authors
 
-Copyright (c)  com.47deg. All rights reserved.
+## Maintainers
 
-Licensed under . See [LICENSE](LICENSE.md) for terms.
+The maintainers of the project are:
+
+
+
+## Contributors
+
+These are the people that have contributed to the _fetchless_ project:
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@
 
 # Contributing
 
-Discussion around _fetchless_ happens in the [GitHub issues](https://github.com//issues) and [pull requests](https://github.com//pulls).
+Discussion around _fetchless_ happens in the [GitHub issues](https://github.com/47degrees/fetchless/issues) and [pull requests](https://github.com/47degrees/fetchless/pulls).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about
 the code. Pull requests are also welcome.
 
 People are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md) when discussing _fetchless_ on the Github page or other venues.
 
-If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [com.47deg](mailto:).
+If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [47 Degrees Open Source](mailto:hello@47deg.com).
 
 ## How can I help?
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C)   com.47deg
+   Copyright (C)  2022 47 Degrees Open Source <https://www.47deg.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -4,6 +4,6 @@
 
 fetchless
 
-Copyright (c)  com.47deg. All rights reserved.
+Copyright (c) 2022 47 Degrees Open Source. All rights reserved.
 
-Licensed under . See [LICENSE](LICENSE.md) for terms.
+Licensed under Apache-2.0. See [LICENSE](LICENSE.md) for terms.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ As listed above in the "key differences" section, a tagless approach has numerou
 The two biggest advantages are speed and API flexibility.
 
 ### Speed
-While not properly benchmarked extensively yet (I wrote this up very quickly and will expand on this later), I've ran some local benchmarks that confirm my initial suspicions about the speed of Fetch vs Fetchless.
+While not properly benchmarked extensively yet (I wrote this up very quickly and will expand on this later), I've ran some local benchmarks that confirm my initial suspicions about the speed of Fetch vs fetchless.
 On a fundamental level, it should make sense that a "Free"-style DSL is slower to at least some degree than a "tagless final"-style one.
 This is because of how they are encoded, since the tagless version is much more direct and has less overhead by definition.
 
@@ -66,8 +66,8 @@ Fetch traverse result
 In each case, the benchmark involves traversing over a list of 50,000 integers and performing a fetch, except for `LazyBatchRequest set` which is an explicit batch and not a traversal.
 For the `immediate` case up top, that is for a direct fetch with no deduping or auto-batching support.
 `LazyRequest` supports deduping and sequencing, but not auto-batching, and `LazyBatchRequest` is an applicative type that supports batches only.
-So in the absolute worst case for Fetchless, it appears that starting with `LazyRequest` and using `parTraverse` to re-encode as a single `LazyBatchRequest` takes well over an order of magnitude less time to perform.
-It's still possible that future changes will bridge this gap slowly, as more features and functionality are added or possible bugs are fixed, but this is a very promising start and shows that even if you choose the slowest possible fetch option in Fetchless, it is still faster than Fetch.
+So in the absolute worst case for fetchless, it appears that starting with `LazyRequest` and using `parTraverse` to re-encode as a single `LazyBatchRequest` takes well over an order of magnitude less time to perform.
+It's still possible that future changes will bridge this gap slowly, as more features and functionality are added or possible bugs are fixed, but this is a very promising start and shows that even if you choose the slowest possible fetch option in fetchless, it is still faster than Fetch.
 
 ### Flexibility
 There are a couple details in Fetch that make it not very flexible in the API department:
@@ -77,7 +77,7 @@ There are a couple details in Fetch that make it not very flexible in the API de
 * `Fetch.run` and similar require the `Concurrent` type class among others, which means that if you are several layers deep into your program you have to depend on this rather heavy type class for your effect type rather than something more simple like `Monad`.
 * Because a `Fetch` is its own effect, implementing features that happen between sequenced fetches requires implementing the functionality inside the library, rather than providing some kind of way for users to hook in and interleve effects.
 
-Fetchless solves this by making the following decisions:
+fetchless solves this by making the following decisions:
 
 * A `Fetch` instance (similar to `DataSource`) has only two main methods: `single` and `batch`, and no dependency on any specific type class.
 * The `Fetch` instance itself should decide if parallelism or maximum-batch-sizes should be considered in cases of fetching multiple IDs in a batch.
@@ -112,7 +112,7 @@ val testDataSource = new DataSource[IO, Int, Int] {
 val testProgram: IO[List[Int]] = OGFetch.run(List(1, 2, 3).map(i => Fetch(i, testDataSource)).sequence)
 ```
 
-For Fetchless, the equivalent code would look like this:
+For fetchless, the equivalent code would look like this:
 
 ```scala
 import cats.effect.IO
@@ -180,3 +180,9 @@ However, you cannot chain them together, so you need to convert back and forth b
 This is done with the `Parallel` instance for `LazyRequest` so you can call `.parTupled`/`.parTraverse` and so on on your independent fetches, and get automatic deduplication and batching just like you did in the original Fetch library, only now you must explicitly opt-in to auto-batching.
 
 For more details, please see the included tests.
+
+# Copyright
+
+fetchless is designed and developed by 47 Degrees Open Source
+
+Copyright (C)  2022 47 Degrees Open Source <https://www.47deg.com>

--- a/build.sbt
+++ b/build.sbt
@@ -2,35 +2,17 @@ ThisBuild / scalaVersion := scala213
 ThisBuild / organization := "com.47deg"
 
 addCommandAlias("ci-test", "scalafmtCheckAll; scalafmtSbtCheck; mdoc; ++test")
-addCommandAlias("ci-docs", "github; mdoc; headerCreateAll; publishMicrosite")
+addCommandAlias("ci-docs", "github; documentation/mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "github; ci-release")
 
 lazy val scala212             = "2.12.15"
 lazy val scala213             = "2.13.8"
-lazy val scala3Version        = "3.0.2"
+lazy val scala3Version        = "3.2.1"
 lazy val scala2Versions       = Seq(scala212, scala213)
 lazy val allScalaVersions     = scala2Versions :+ scala3Version
 lazy val scalaVersions213Plus = Seq(scala213, scala3Version)
 
 publish / skip := true
-
-lazy val root = (project in file("."))
-  .settings(
-    publish / skip := true
-  )
-  .aggregate(
-    fetchlessJVM,
-    fetchlessJS,
-    fetchlessDebugJVM,
-    fetchlessDebugJS,
-    fetchlessDoobieJVM,
-    fetchlessStreamingJVM,
-    fetchlessStreamingJS,
-    fetchlessHttp4sJVM,
-    fetchlessHttp4sJS,
-    fetchlessHttp4s023JVM,
-    fetchlessHttp4s023JS
-  )
 
 lazy val fetchless = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -58,7 +40,7 @@ lazy val fetchlessStreaming = crossProject(JSPlatform, JVMPlatform)
 
 lazy val fetchlessStreamingJVM = fetchlessStreaming.jvm
 lazy val fetchlessStreamingJS = fetchlessStreaming.js
-  .settings(crossScalaVersions := allScalaVersions)
+  .settings(crossScalaVersions := scala2Versions)
 
 lazy val fetchlessHttp4s = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -67,7 +49,8 @@ lazy val fetchlessHttp4s = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(fetchlessStreaming % "compile->compile;test->test")
 
 lazy val fetchlessHttp4sJVM = fetchlessHttp4s.jvm
-lazy val fetchlessHttp4sJS  = fetchlessHttp4s.js
+lazy val fetchlessHttp4sJS = fetchlessHttp4s.js
+  .settings(crossScalaVersions := Seq(scala213))
 
 lazy val fetchlessHttp4s023 = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -76,7 +59,8 @@ lazy val fetchlessHttp4s023 = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(fetchlessStreaming % "compile->compile;test->test")
 
 lazy val fetchlessHttp4s023JVM = fetchlessHttp4s023.jvm
-lazy val fetchlessHttp4s023JS  = fetchlessHttp4s023.js
+lazy val fetchlessHttp4s023JS = fetchlessHttp4s023.js
+  .settings(crossScalaVersions := scala2Versions)
 
 lazy val fetchlessDoobie = crossProject(JVMPlatform)
   .crossType(CrossType.Pure)
@@ -85,3 +69,8 @@ lazy val fetchlessDoobie = crossProject(JVMPlatform)
   .dependsOn(fetchlessStreaming % "compile->compile;test->test")
 
 lazy val fetchlessDoobieJVM = fetchlessDoobie.jvm
+
+lazy val documentation = project
+  .enablePlugins(MdocPlugin)
+  .settings(mdocOut := file("."))
+  .settings(publish / skip := true)

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -2,8 +2,16 @@
 [comment]: <> (It is automatically updated after every release of https://github.com/47degrees/.github)
 [comment]: <> (If you want to suggest a change, please open a PR or issue in that repository)
 
-fetchless
+# Authors
 
-Copyright (c)  com.47deg. All rights reserved.
+## Maintainers
 
-Licensed under . See [LICENSE](LICENSE.md) for terms.
+The maintainers of the project are:
+
+@COLLABORATORS@
+
+## Contributors
+
+These are the people that have contributed to the _@NAME@_ project:
+
+@CONTRIBUTORS@

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+[comment]: <> (Don't edit this file!)
+[comment]: <> (It is automatically updated after every release of https://github.com/47degrees/.github)
+[comment]: <> (If you want to suggest a change, please open a PR or issue in that repository)
+
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the
+[Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+[member of the project](AUTHORS.md#maintainers).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,18 +4,18 @@
 
 # Contributing
 
-Discussion around _fetchless_ happens in the [GitHub issues](https://github.com//issues) and [pull requests](https://github.com//pulls).
+Discussion around _@NAME@_ happens in the [GitHub issues](https://github.com/@REPO@/issues) and [pull requests](https://github.com/@REPO@/pulls).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about
 the code. Pull requests are also welcome.
 
-People are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md) when discussing _fetchless_ on the Github page or other venues.
+People are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md) when discussing _@NAME@_ on the Github page or other venues.
 
-If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [com.47deg](mailto:).
+If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [@ORG_NAME@](mailto:@ORG_EMAIL@).
 
 ## How can I help?
 
-_fetchless_ follows a standard [fork and pull](https://help.github.com/articles/using-pull-requests/) model for contributions via GitHub pull requests.
+_@NAME@_ follows a standard [fork and pull](https://help.github.com/articles/using-pull-requests/) model for contributions via GitHub pull requests.
 
 The process is simple:
 

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C)   com.47deg
+   Copyright (C)  @YEAR_RANGE@ @COPYRIGHT_OWNER@
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/NOTICE.md
+++ b/docs/NOTICE.md
@@ -2,8 +2,8 @@
 [comment]: <> (It is automatically updated after every release of https://github.com/47degrees/.github)
 [comment]: <> (If you want to suggest a change, please open a PR or issue in that repository)
 
-fetchless
+@NAME@
 
-Copyright (c)  com.47deg. All rights reserved.
+Copyright (c) @YEAR_RANGE@ @ORG_NAME@. All rights reserved.
 
-Licensed under . See [LICENSE](LICENSE.md) for terms.
+Licensed under @LICENSE@. See [LICENSE](LICENSE.md) for terms.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,188 @@
+# @NAME@ (proof of concept)
+A port of the Fetch library to Tagless Final style
+
+## Key Differences
+* Encoded in tagless final style first, instead of as a data structure
+* No need for explicit support for logging, timing, rate-limiting, timeouts, etc. as those can use your base effect type.
+* Less runtime overhead due to being implemented in terms of existing effects, rather than as its own effect.
+* Potentially orders of magnitude faster than original Fetch
+* Core code is very small, most code is actually just implicit syntax wrappers for collections & tuples.
+* No required type class dependencies to call fetching methods (after creating a `Fetch` instance)
+
+## Motivation
+In Fetch 3.0.0, I made a decision to remove the guarantee for implicit batching on `sequence`/`traverse` calls due to the behavior breaking from a Cats version upgrade.
+This is reverted as of 3.1.0, but it seemed best at the time with what limited perspective I had that maybe we should instead introduce explicit batching syntax.
+In hindsight, I think this makes Fetch somewhat less useful and have considered the alternatives.
+
+The entire point of Fetch, in a sense, is to auto-batch and parallelize requests wherever possible.
+It does this by encoding a DSL for fetches as an explicit effect type that is interpreted later, using a custom `Monad` instance with overrides on certain applicative methods.
+There are some pros and cons with this approach:
+
+Pros:
+* You don't have to explicitly call `Parallel` methods such as `parTupled`/`parTraverse`/`parSequence` in order to invoke concurrency and batching, and can just use `.tupled`/`.traverse`/`.sequence` as normal.
+* You can treat it as an effect type on its own, and use it in any code that depends on the `Monad` type class.
+
+Cons:
+* The abstraction breaks down slightly in assuming that users will know and understand that `flatMap` is strictly sequential, whereas `tupled`/`traverse` might not be. So to optimize fetches, the user needs to be aware of whether or not these `Applicative` methods can be used instead of monadic ones, and in that case it could be argued that the user might as well just explicitly ask for batching in those cases (since those functions require an applicative-friendly signature anyhow)
+* Requires custom code for features such as logging, timing, timeouts, etc. for any intermediate fetch.
+* Must be interpreted at runtime from its reified form, which also implies leaking the `Concurrent` implementation detail for when you plug in an effect type.
+* Can break at a moment's notice if any implementation details in Cats that this depends on for auto-batching support lawfully change (as did happen before 3.0.0)
+
+As listed above in the "key differences" section, a tagless approach has numerous advantages.
+The two biggest advantages are speed and API flexibility.
+
+### Speed
+While not properly benchmarked extensively yet (I wrote this up very quickly and will expand on this later), I've ran some local benchmarks that confirm my initial suspicions about the speed of Fetch vs @NAME@.
+On a fundamental level, it should make sense that a "Free"-style DSL is slower to at least some degree than a "tagless final"-style one.
+This is because of how they are encoded, since the tagless version is much more direct and has less overhead by definition.
+
+Here is some code from a (currently local, unpublished) benchmark that should get the point across (time in nanoseconds)
+
+(average, in nanoseconds, over 40 runs)
+
+```
+Immediate fetch traverse result
+1.12204425E7
+Immediate deduped fetch traverse result
+1.58746375E7
+LazyRequest traverse result
+5.33710375E7
+LazyBatchRequest set result
+6.621083E7
+LazyBatchRequest traverse result
+1.01090145E8
+LazyRequest parTraverse result
+1.54424665E8
+```
+
+Doing an identical benchmark on Fetch, looks like the following:
+
+(average, in nanoseconds, over 40 runs)
+```
+Fetch traverse result
+7.6349248325E9
+```
+
+In each case, the benchmark involves traversing over a list of 50,000 integers and performing a fetch, except for `LazyBatchRequest set` which is an explicit batch and not a traversal.
+For the `immediate` case up top, that is for a direct fetch with no deduping or auto-batching support.
+`LazyRequest` supports deduping and sequencing, but not auto-batching, and `LazyBatchRequest` is an applicative type that supports batches only.
+So in the absolute worst case for @NAME@, it appears that starting with `LazyRequest` and using `parTraverse` to re-encode as a single `LazyBatchRequest` takes well over an order of magnitude less time to perform.
+It's still possible that future changes will bridge this gap slowly, as more features and functionality are added or possible bugs are fixed, but this is a very promising start and shows that even if you choose the slowest possible fetch option in @NAME@, it is still faster than Fetch.
+
+### Flexibility
+There are a couple details in Fetch that make it not very flexible in the API department:
+
+* `DataSource` instances must contain a `Concurrent` instance for the effect type, even if it is not used in an implementation, simply because it is possible that it could be.
+* It must also specify an execution style and a maximum count for batches, if any. These feel like leaking implementation details that could just be closed over in the implementation.
+* `Fetch.run` and similar require the `Concurrent` type class among others, which means that if you are several layers deep into your program you have to depend on this rather heavy type class for your effect type rather than something more simple like `Monad`.
+* Because a `Fetch` is its own effect, implementing features that happen between sequenced fetches requires implementing the functionality inside the library, rather than providing some kind of way for users to hook in and interleve effects.
+
+@NAME@ solves this by making the following decisions:
+
+* A `Fetch` instance (similar to `DataSource`) has only two main methods: `single` and `batch`, and no dependency on any specific type class.
+* The `Fetch` instance itself should decide if parallelism or maximum-batch-sizes should be considered in cases of fetching multiple IDs in a batch.
+* The paradigm becomes less about "invisibly batching fetches", and more about describing your data models as "fetchable" by providing a `Fetch` instance for them. Given a `Fetch` instance exists for some type in the current scope, you can use `.fetch`/`.fetchAll`/`.fetchTupled`/`.fetchLazy` syntax on any ID value or collection.
+* For all additional functionality, we can use the base effect system, reducing maintenance burden as well as increasing efficiency.
+
+## Examples
+
+To demonstrate the way this works, consider the following example code:
+
+```scala
+import cats.effect.IO
+import cats.syntax.all._
+import fetch.DataSource
+import fetch.{Fetch => OGFetch}
+
+//Given an Int, returns it back
+val testDataSource = new DataSource[IO, Int, Int] {
+  def data: Data[Int, Int] = new Data[Int, Int] {
+    def name: String = "TestDataSource"
+  }
+
+  implicit def CF: Concurrent[IO] = Concurrent[IO]
+
+  def fetch(id: Int): IO[Option[Int]] = IO.pure(Some(id))
+
+  override def batch(ids: NonEmptyList[Int]): IO[Map[Int, Int]] =
+    IO.pure(ids.toList.map(i => i -> i).toMap)
+
+}
+
+val testProgram: IO[List[Int]] = OGFetch.run(List(1, 2, 3).map(i => Fetch(i, testDataSource)).sequence)
+```
+
+For @NAME@, the equivalent code would look like this:
+
+```scala
+import cats.effect.IO
+import cats.syntax.all._
+import @NAME@.Fetch
+import @NAME@.syntax._
+
+//Constructor for Fetch instances that will run all batches as single fetches in a strict linear sequence.
+implicit val testFetch: Fetch[IO, Int, Int] = Fetch.singleSequenced(i => IO.pure(i))
+
+val testProgram: IO[Map[Int, Int]] = List(1, 2, 3).fetchAll
+```
+
+There are a couple minor differences in the API type signatures, but the general idea is the same.
+You can fetch single items with one ID, and you can request multiple IDs at once in a batch.
+The actual implementation of batches is entirely contained in the `Fetch` instance you create, so you no longer have to
+specify if you want to run fetches in parallel or in a linear sequence.
+As long as you are fetching more than one ID at a time, it is guaranteed to use whatever behavior the batch implementation of your `Fetch` instance is designed to do.
+
+Here are the current constructors for `Fetch` instances:
+
+* `singleSequenced` - Only runs single fetches, and batches are ran as sequential. Requires `Applicative`.
+* `singleParallel` - Runs batches in parallel. Requires `Applicative` and `Parallel`.
+* `batchable` - Allows you to specify your own functions for `single` and `batch` fetches. No type class constraints (assumed the user will have their own).
+* `batchOnly` - Runs batches only, and encodes single fetches as a one-element batch. Requires `Applicative`. Whether or not batches are in parallel depends on the user's supplied function for the batch.
+* `const` - A constant `Fetch` that retrieves from an in-memory map.
+* `echo` - A `Fetch` that returns the input the user provides, great for tests.
+
+And of course you can always create your own instance, though `batchable` winds up being the same thing with less boilerplate.
+
+To get around the problem of how to do auto-batching, the solution is to simply defer to the current `Fetch` implementation that the user wires in.
+The important details should be just that the user is requesting data, either one-at-a-time or in a batch.
+Exactly how that batch is acquired, just like the original Fetch library, is unimportant at the point it is being used.
+The user does not select `traverse` vs `parTraverse`, and so on, but instead they can use the following syntax:
+
+```scala
+val exampleId = 5
+
+val singleFetch: IO[Option[Int]] = 5.fetch[Id, Int, Int] //Can also manually supply the Fetch instance
+
+val effectfulFetch: IO[Option[Int]] = IO(5).fetch[Int]
+
+val traverseFetch: IO[Map[Int, Int]] = List(5).fetchAll //Also configured to work on tuples
+
+val tupledFetch: IO[(Option[Int], Option[Int], Option[Int])] = (5, 5, 5).fetchTupled
+```
+
+This also side-steps the problem of needing to provide explicit support for popular user-requested features, since all fetches are always directly implemented in terms of `F[_]` and can be manipulated with whatever libraries and combinators users already use (including whatever is in the CE3 standard library)
+
+## DedupedRequest
+
+One feature not supported in a standard fetch is deduping, since that requires some kind of context to pass around.
+I've added a type `DedupedRequest` and operators to fetch using this provided context, so that in any context you can make very efficient fetches that depend on previous fetches for caching and deduplication.
+
+## LazyRequest and LazyBatchRequest
+
+The `Fetch` instance can not only deduplicate fetches with `DedupedRequest` but it can also create lazy fetches that approximate the behaavior found in the original `Fetch` library with regards to not only deduplication, but also automatic batching.
+
+A `LazyRequest` is created when you call `.fetchLazy` on an ID, or call `.singleLazy`/`.batchLazy` on a `Fetch` instance.
+It is essentially just a wrapper type that encodes the intention to chain fetch calls together, so you can `flatMap` multiples of them in sequence and raise effects into its context with `LazyRequest.liftF`/`LazyBatchRequest.liftF`.
+
+`LazyBatchRequest` is the parallel of `LazyRequest` which is not monadic, but only `Applicative` and represents the intention to group multiple fetches into a batch.
+You can combine them together with `.tupled` and `.traverse`-style methods that work for any `Applicative` and it will guarantee to put all of your requests into a single batch per-fetch-instance.
+However, you cannot chain them together, so you need to convert back and forth between `LazyRequest` and `LazyBatchRequest` to keep dependent sequencing along with auto-batching.
+This is done with the `Parallel` instance for `LazyRequest` so you can call `.parTupled`/`.parTraverse` and so on on your independent fetches, and get automatic deduplication and batching just like you did in the original Fetch library, only now you must explicitly opt-in to auto-batching.
+
+For more details, please see the included tests.
+
+# Copyright
+
+@NAME@ is designed and developed by @ORG_NAME@
+
+Copyright (C)  @YEAR_RANGE@ @COPYRIGHT_OWNER@

--- a/fetchless/src/main/scala-2.12/fetchless/Cols.scala
+++ b/fetchless/src/main/scala-2.12/fetchless/Cols.scala
@@ -5,8 +5,8 @@ object Cols {
   def map[A, B, C, D](map: Map[A, B])(f: ((A, B)) => (C, D)): Map[C, D] =
     map.map(f)
 
-  def mapValues[A, B, C](map: Map[A, B])(f: B => (C)): Map[A, C] =
-    map.mapValues(f).toMap
+  def mapValues[A, B, C](map: Map[A, B])(f: B => C): Map[A, C] =
+    map.mapValues(f)
 
   def collect[A, B, C, D](map: Map[A, B])(f: PartialFunction[(A, B), (C, D)]): Map[C, D] =
     map.collect(f)

--- a/fetchless/src/main/scala-2.12/fetchless/Cols.scala
+++ b/fetchless/src/main/scala-2.12/fetchless/Cols.scala
@@ -1,0 +1,14 @@
+package fetchless
+
+object Cols {
+
+  def map[A, B, C, D](map: Map[A, B])(f: ((A, B)) => (C, D)): Map[C, D] =
+    map.map(f)
+
+  def mapValues[A, B, C](map: Map[A, B])(f: B => (C)): Map[A, C] =
+    map.mapValues(f).toMap
+
+  def collect[A, B, C, D](map: Map[A, B])(f: PartialFunction[(A, B), (C, D)]): Map[C, D] =
+    map.collect(f)
+
+}

--- a/fetchless/src/main/scala-2.13/fetchless/Cols.scala
+++ b/fetchless/src/main/scala-2.13/fetchless/Cols.scala
@@ -1,0 +1,14 @@
+package fetchless
+
+object Cols {
+
+  def map[A, B, C, D](map: Map[A, B])(f: ((A, B)) => (C, D)): Map[C, D] =
+    map.view.map(f).toMap
+
+  def mapValues[A, B, C](map: Map[A, B])(f: B => (C)): Map[A, C] =
+    map.view.mapValues(f).toMap
+
+  def collect[A, B, C, D](map: Map[A, B])(f: PartialFunction[(A, B), (C, D)]): Map[C, D] =
+    map.collect(f)
+
+}

--- a/fetchless/src/main/scala-3/fetchless/Cols.scala
+++ b/fetchless/src/main/scala-3/fetchless/Cols.scala
@@ -1,0 +1,14 @@
+package fetchless
+
+object Cols {
+
+  def map[A, B, C, D](map: Map[A, B])(f: ((A, B)) => (C, D)): Map[C, D] =
+    map.view.map(f).toMap
+
+  def mapValues[A, B, C](map: Map[A, B])(f: B => (C)): Map[A, C] =
+    map.view.mapValues(f).toMap
+
+  def collect[A, B, C, D](map: Map[A, B])(f: PartialFunction[(A, B), (C, D)]): Map[C, D] =
+    map.collect(f)
+
+}

--- a/fetchless/src/main/scala/fetchless/Fetch.scala
+++ b/fetchless/src/main/scala/fetchless/Fetch.scala
@@ -161,9 +161,9 @@ object Fetch {
         batch(iSet).map { resultMap =>
           val missing = iSet.diff(resultMap.keySet)
           val initialCache: FetchCache = FetchCache(
-            resultMap.view
-              .map[(I, FetchId), Option[A]] { case (i, a) => (i -> wrappedId) -> a.some }
-              .toMap,
+            Cols.map(resultMap) { case (i, a) =>
+              (i -> wrappedId) -> a.some
+            },
             Set.empty
           )
           val missingCache: FetchCache =
@@ -288,7 +288,7 @@ object Fetch {
           { is =>
             val setMap = is.toList.map(c => f(c) -> c).toMap
             val inSet  = setMap.keySet
-            fab.batch(inSet).map(m => m.map[C, D] { case (a, b) => setMap.apply(a) -> g(b) })
+            fab.batch(inSet).map(Cols.map(_) { case (a, b) => setMap.apply(a) -> g(b) })
           }
         )
 
@@ -297,7 +297,7 @@ object Fetch {
       override def rmap[A, B, C](fab: Fetch[F, A, B])(f: B => C): Fetch[F, A, C] =
         default[F, A, C](fab.id)(
           i => fab.single(i).map(_.map(f)),
-          is => fab.batch(is).map(_.view.mapValues(f).toMap)
+          is => fab.batch(is).map(Cols.mapValues(_)(f))
         )
     }
 }

--- a/fetchless/src/main/scala/fetchless/FetchCache.scala
+++ b/fetchless/src/main/scala/fetchless/FetchCache.scala
@@ -25,14 +25,14 @@ final case class FetchCache(cacheMap: CacheMap, fetchAllAcc: Set[FetchId.StringI
     cacheMap.get(i -> fetch.wrappedId).flatten.asInstanceOf[Option[A]]
 
   /** Accesses every value for a given fetch in this cache */
-  def getMap[F[_], I, A](fetch: Fetch[F, I, A]): Map[I, A] = cacheMap.collect[I, A] {
+  def getMap[F[_], I, A](fetch: Fetch[F, I, A]): Map[I, A] = cacheMap.collect {
     case ((i, fid), Some(b)) if (fid == fetch.wrappedId) =>
       i.asInstanceOf[I] -> b.asInstanceOf[A]
   }
 
   /** Like `getMap` but exclusively collects the IDs specified. */
   def getMapForSet[F[_], I, A](fetch: Fetch[F, I, A])(iSet: Set[I]): Map[I, A] =
-    cacheMap.collect[I, A] {
+    cacheMap.collect {
       case ((i, fid), Some(b))
           if (fid == fetch.wrappedId && iSet.asInstanceOf[Set[Any]].contains(i)) =>
         i.asInstanceOf[I] -> b.asInstanceOf[A]

--- a/fetchless/src/main/scala/fetchless/syntax.scala
+++ b/fetchless/src/main/scala/fetchless/syntax.scala
@@ -1,12 +1,18 @@
 package fetchless
 
 import cats.{FlatMap, Functor, Traverse}
-import cats.syntax.all._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import cats.Monad
-import cats.data.Kleisli
 import cats.Applicative
 
 object syntax {
+
+  implicit def dfFunctor[F[_]: Functor]: Functor[DedupedRequest[F, *]] =
+    DedupedRequest.dedupedRequestF[F]
+
+  implicit def lrFunctor[F[_]: Functor]: Functor[LazyRequest[F, *]] =
+    LazyRequest.lazyRequestF[F]
 
   implicit class FDedupedRequestSyntax[F[_]: FlatMap, A](fdf: F[DedupedRequest[F, A]]) {
     def alsoFetch[I, B](i: I)(implicit fetch: Fetch[F, I, B]): F[DedupedRequest[F, Option[B]]] =

--- a/fetchless/src/test/scala/fetchless/DedupingSpec.scala
+++ b/fetchless/src/test/scala/fetchless/DedupingSpec.scala
@@ -49,12 +49,13 @@ class DedupingSpec extends FunSuite {
   test("Dedupe across multiple fetches") {
     var timesIntsFetched = 0
 
-    implicit val intFetch = Fetch.singleSequenced[Id, Int, Int]("intFetch") { i =>
-      timesIntsFetched += 1
-      Some(i)
+    implicit val intFetch: Fetch[Id, Int, Int] = Fetch.singleSequenced[Id, Int, Int]("intFetch") {
+      i =>
+        timesIntsFetched += 1
+        Some(i)
     }
 
-    implicit val boolFetch = Fetch.batchable[Id, Boolean, Boolean](
+    implicit val boolFetch: Fetch[Id, Boolean, Boolean] = Fetch.batchable[Id, Boolean, Boolean](
       "boolFetch"
     )(i => Some(i))(iSet => iSet.toList.map(i => (i, i)).toMap)
 

--- a/fetchless/src/test/scala/fetchless/LazyRequestSpec.scala
+++ b/fetchless/src/test/scala/fetchless/LazyRequestSpec.scala
@@ -2,26 +2,22 @@ package fetchless
 
 import syntax._
 
-import cats.syntax.all._
 import cats._
-import cats.effect.IO
-
-import cats.effect.unsafe.implicits.global
-import cats.effect.kernel.Ref
+import cats.syntax.all._
+import cats.effect.{IO, Ref}
 import munit.CatsEffectSuite
-import cats.effect.Clock
 
 class LazyRequestSpec extends CatsEffectSuite {
 
   test("LazyRequest allows for non-linear deduping") {
-    def intFetch(countRef: Ref[IO, Int], logRef: Ref[IO, List[Int]]) =
+    def intFetch(countRef: Ref[IO, Int], logRef: Ref[IO, List[Int]]): Fetch[IO, Int, Int] =
       Fetch.singleSequenced[IO, Int, Int]("intFetch")(i =>
         countRef.update(_ + 1) >> logRef.update(_ :+ i) >> IO(i.some)
       )
 
     val firstProgram = (IO.ref(0), IO.ref(List.empty[Int])).tupled.flatMap {
       case (countRef, logRef) =>
-        implicit val fetch = intFetch(countRef, logRef)
+        implicit val fetch: Fetch[IO, Int, Int] = intFetch(countRef, logRef)
 
         val fetchProgram = fetch.singleLazy(1) >> fetch.singleLazy(2) >> fetch.singleLazy(2)
         val testProgram  = fetchProgram.run >> (countRef.get, logRef.get).tupled
@@ -31,7 +27,7 @@ class LazyRequestSpec extends CatsEffectSuite {
 
     val secondProgram = (IO.ref(0), IO.ref(List.empty[Int])).tupled.flatMap {
       case (countRef, logRef) =>
-        implicit val fetch = intFetch(countRef, logRef)
+        implicit val fetch: Fetch[IO, Int, Int] = intFetch(countRef, logRef)
 
         val fetchProgram = (fetch.singleLazy(2) >> fetch
           .singleLazy(1)) >> (fetch.singleLazy(1) >> fetch.singleLazy(2) >> fetch
@@ -47,7 +43,7 @@ class LazyRequestSpec extends CatsEffectSuite {
   test("Has a parallel instance with LazyBatchRequest") {
     var timesBatchCalled = 0
 
-    implicit val intFetch = Fetch.batchable[Id, Int, Int]("intFetch") { i =>
+    implicit val intFetch: Fetch[Id, Int, Int] = Fetch.batchable[Id, Int, Int]("intFetch") { i =>
       Some(i)
     } { is =>
       timesBatchCalled += 1
@@ -85,13 +81,15 @@ class LazyRequestSpec extends CatsEffectSuite {
   }
 
   test("Runs requests across multiple sources") {
-    implicit val intFetch = Fetch.singleSequenced[Id, Int, Int]("intFetch") { i =>
-      Some(i)
+    implicit val intFetch: Fetch[Id, Int, Int] = Fetch.singleSequenced[Id, Int, Int]("intFetch") {
+      i =>
+        Some(i)
     }
 
-    implicit val boolFetch = Fetch.singleSequenced[Id, Boolean, Boolean]("boolFetch") { i =>
-      Some(i)
-    }
+    implicit val boolFetch: Fetch[Id, Boolean, Boolean] =
+      Fetch.singleSequenced[Id, Boolean, Boolean]("boolFetch") { i =>
+        Some(i)
+      }
 
     val fewInts     = intFetch.batchLazy(Set(1, 2, 3))
     val two         = LazyRequest.liftF[Id, String]("Hello world!")("two")

--- a/fetchless/src/test/scala/fetchless/LazyRequestSpec.scala
+++ b/fetchless/src/test/scala/fetchless/LazyRequestSpec.scala
@@ -199,7 +199,7 @@ class LazyRequestSpec extends CatsEffectSuite {
     checkResult >> checkCounter
   }
 
-  test("Dedupes AllFetch requests (parallel)".only) {
+  test("Dedupes AllFetch requests (parallel)") {
     var counter = 0
 
     val boolFetch = AllFetch.fromExisting(Fetch.echo[IO, Boolean]("boolFetch"))(IO {

--- a/fetchless/src/test/scala/fetchless/SyntaxSpec.scala
+++ b/fetchless/src/test/scala/fetchless/SyntaxSpec.scala
@@ -8,7 +8,7 @@ import munit.FunSuite
 
 class SyntaxSpec extends FunSuite {
 
-  implicit val dummyFetch =
+  implicit val dummyFetch: Fetch[Id, Int, Int] =
     Fetch.echo[Id, Int]("intFetch")
 
   test("List batching") {

--- a/fetchlessDoobie/src/main/scala/fetchless/doobie/DoobieFetch.scala
+++ b/fetchlessDoobie/src/main/scala/fetchless/doobie/DoobieFetch.scala
@@ -68,7 +68,7 @@ object DoobieFetch {
       xa: Transactor[F]
   )(single: Query[I, A])(batch: Set[I] => Query0[(I, A)]): Fetch[F, I, A] = {
     val baseFetch = Fetch.batchable[F, I, A](fetchId)(i => single.option(i).transact(xa))(s =>
-      batch(s).toMap.transact(xa)
+      batch(s).toMap[I, A].transact(xa)
     )
     StreamingFetch.wrapExistingGuaranteed(baseFetch)(iSet => batch(iSet).stream.transact(xa))
   }
@@ -104,11 +104,11 @@ object DoobieFetch {
       single: Query[I, A]
   )(batch: Set[I] => Query0[(I, A)])(batchAll: Query0[(I, A)]): Fetch[F, I, A] = {
     val baseFetch = Fetch.batchable[F, I, A](fetchId)(i => single.option(i).transact(xa))(s =>
-      batch(s).toMap.transact(xa)
+      batch(s).toMap[I, A].transact(xa)
     )
     val streamingFetch =
       StreamingFetch.wrapExistingGuaranteed(baseFetch)(iSet => batch(iSet).stream.transact(xa))
-    StreamingAllFetch.fromExistingStreamingFetch(streamingFetch)(batchAll.toMap.transact(xa))(
+    StreamingAllFetch.fromExistingStreamingFetch(streamingFetch)(batchAll.toMap[I, A].transact(xa))(
       batchAll.stream.transact(xa)
     )
   }


### PR DESCRIPTION
This PR:

* Brings the CI to the repo
* Adds the default files
* Fixes the compilation errors associated with Scala 2.12. The changes can be reviewed in these two commits:
  * https://github.com/47degrees/fetchless/pull/24/commits/337ef85d09ddfffe42d1bbc28f20a296b9b26339?diff=unified&w=1
  * https://github.com/47degrees/fetchless/pull/24/commits/3feda4aa81f157f8235baa51531814bbf99a496d

The main problems came with the Scala collections. I've created three directories for a utility class that abstracts the other parts from the details. Let me know if you think there's a better way.